### PR TITLE
fix docker example, ABS name capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AudioBookRequest
 
-Your tool for handling audiobook requests on a Plex/AudioBookShelf/Jellyfin instance.
+Your tool for handling audiobook requests on a Plex/Audiobookshelf/Jellyfin instance.
 
 If you've heard of Overseer, Ombi, or Jellyseer; this is in the similar vein, <ins>but for audiobooks</ins>.
 
@@ -20,7 +20,7 @@ Using Docker, this website can be run with minimal setup:
 ```dockerfile
 services:
   web:
-    build: markbeep/audiobookrequest
+    image: markbeep/audiobookrequest
     ports:
       - "8000:8765"
     environment:


### PR DESCRIPTION
The Docker example doesn't work in the current form, `build` should be `image`. Also changed the ABS name capitalization according to their branding guidelines.