### PR TITLE
remove strict password rules and allow min length to be customized

### DIFF
--- a/app/routers/root.py
+++ b/app/routers/root.py
@@ -76,7 +76,7 @@ def create_init(
         )
 
     try:
-        raise_for_invalid_password(password, confirm_password)
+        raise_for_invalid_password(session, password, confirm_password)
     except HTTPException as e:
         return templates.TemplateResponse(
             "init.html",

--- a/templates/init.html
+++ b/templates/init.html
@@ -39,9 +39,6 @@
       name="password"
       type="password"
       class="input w-full"
-      pattern="(?=[^A-Z]*[A-Z])(?=[^a-z]*[a-z])(?=\D*\d).{8,}"
-      oninvalid="this.setCustomValidity('Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number')"
-      oninput="this.setCustomValidity('')"
       required
     />
 
@@ -51,9 +48,6 @@
       name="confirm_password"
       type="password"
       class="input w-full"
-      pattern="(?=[^A-Z]*[A-Z])(?=[^a-z]*[a-z])(?=\D*\d).{8,}"
-      oninvalid="this.setCustomValidity('Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number')"
-      oninput="this.setCustomValidity('')"
       required
     />
 

--- a/templates/settings_page/account.html
+++ b/templates/settings_page/account.html
@@ -1,12 +1,26 @@
 {% extends "settings_page/base.html" %} {% block head %}
 <title>Settings - Account</title>
-{% endblock %} {% block content %}
+{% include 'scripts/toast.html' %} {% endblock %} {% block content %}
 <form
   id="change-password-form"
   class="flex flex-col gap-2"
   hx-post="/settings/account/password"
-  hx-target="#change-pw-error"
+  hx-target="this"
 >
+  {% if success %}
+  <script>
+    toast("{{success|safe}}", "success");
+  </script>
+  {% endif %} {% block error %}
+  <div id="error" class="hidden">
+    {% if error %}
+    <script>
+      toast("{{error|safe}}", "error");
+    </script>
+    {% endif %}
+  </div>
+  {% endblock %}
+
   <h2 class="text-lg">Change Password</h2>
 
   <label for="old-password">Old password</label>
@@ -18,15 +32,12 @@
     required
   />
 
-  <label for="change-password-1">Password</label>
+  <label for="change-password-1">New Password</label>
   <input
     id="change-password-1"
     name="password"
     type="password"
     class="input w-full"
-    pattern="(?=[^A-Z]*[A-Z])(?=[^a-z]*[a-z])(?=\D*\d).{8,}"
-    oninvalid="this.setCustomValidity('Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number')"
-    oninput="this.setCustomValidity('')"
     required
   />
 
@@ -36,15 +47,8 @@
     name="confirm_password"
     type="password"
     class="input w-full"
-    pattern="(?=[^A-Z]*[A-Z])(?=[^a-z]*[a-z])(?=\D*\d).{8,}"
-    oninvalid="this.setCustomValidity('Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number')"
-    oninput="this.setCustomValidity('')"
     required
   />
-
-  {% block change_pw_messages %}
-  <span id="change-pw-error" class="text-red-400">{{ error }}</span>
-  {% endblock %}
 
   <button name="submit" class="btn btn-primary" type="submit">
     Change password

--- a/templates/settings_page/security.html
+++ b/templates/settings_page/security.html
@@ -47,6 +47,16 @@
       value="{{ access_token_expiry }}"
     />
 
+    <label for="pw-len-input">Minimum Password Length</label>
+    <input
+      id="pw-len-input"
+      type="number"
+      name="min_password_length"
+      class="input w-full"
+      placeholder="1"
+      value="{{ min_password_length }}"
+    />
+
     <button
       id="save-button"
       name="submit"

--- a/templates/settings_page/users.html
+++ b/templates/settings_page/users.html
@@ -28,9 +28,6 @@
     name="password"
     type="password"
     class="input w-full"
-    pattern="(?=[^A-Z]*[A-Z])(?=[^a-z]*[a-z])(?=\D*\d).{8,}"
-    oninvalid="this.setCustomValidity('Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number')"
-    oninput="this.setCustomValidity('')"
     required
   />
 


### PR DESCRIPTION
Removes strict password rules. Instead, an admin can define the minimum required length of passwords which is by default set to an insecure length of `1`.