### PR TITLE
Added Event Variables: bookASIN and torrentInfoHash

### DIFF
--- a/app/internal/query.py
+++ b/app/internal/query.py
@@ -89,6 +89,7 @@ async def query_sources(
                 indexer_id=ranked[0].indexer_id,
                 requester_username=requester_username,
                 book_asin=asin,
+                download_url=ranked[0].download_url,
             )
             if resp.ok:
                 same_books = session.exec(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "alembic",
     "argon2-cffi",
     "argon2-cffi-bindings",
+    "bencodepy",
     "fastapi[standard]",
     "itsdangerous",
     "jinja2",

--- a/templates/settings_page/notifications.html
+++ b/templates/settings_page/notifications.html
@@ -58,7 +58,7 @@
 
     <p class="text-xs opacity-60">
       Possible event variables:
-      <span class="font-mono">eventType, eventUser, bookTitle, bookAuthors, bookNarrators</span>
+      <span class="font-mono">eventType, eventUser, bookTitle, bookAuthors, bookNarrators, bookASIN, torrentInfoHash</span>
       <br />
       Failed download event additionally has:
       <span class="font-mono">errorStatus, errorReason</span>

--- a/uv.lock
+++ b/uv.lock
@@ -162,6 +162,7 @@ dependencies = [
     { name = "alembic" },
     { name = "argon2-cffi" },
     { name = "argon2-cffi-bindings" },
+    { name = "bencodepy" },
     { name = "fastapi", extra = ["standard"] },
     { name = "itsdangerous" },
     { name = "jinja2" },
@@ -195,6 +196,7 @@ requires-dist = [
     { name = "alembic" },
     { name = "argon2-cffi" },
     { name = "argon2-cffi-bindings" },
+    { name = "bencodepy" },
     { name = "fastapi", extras = ["standard"] },
     { name = "itsdangerous" },
     { name = "jinja2" },
@@ -221,6 +223,12 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
 ]
+
+[[package]]
+name = "bencodepy"
+version = "0.9.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/72/e2ee9f8a93c92af1ba2d7ef903fd653ef397564ef7715c6ab3eb462f6e29/bencodepy-0.9.5.zip", hash = "sha256:af472134d73ea58edab3c2cb2f2cf61eb9d783908284c3d2d5b1cfd38df864b8", size = 3598, upload-time = "2015-10-16T21:30:09.066Z" }
 
 [[package]]
 name = "certifi"


### PR DESCRIPTION
I needed some extra information from ABR in order to track the torrent download and match it up with its ASIN. 
The change downloads the final chosen torrent and generates the InfoHash of it, which can then be matched up with the torrent entry in the download client. Along with the ASIN variable, it is now possible to have an external script grab and apply proper metadata once the download is complete.