### PR TITLE
feat: Add bookCover as possible notification attribute. Use placeholder for manual and test notifications.

### DIFF
--- a/app/internal/notifications.py
+++ b/app/internal/notifications.py
@@ -14,6 +14,7 @@ from app.internal.models import (
 from app.util import json_type
 from app.util.db import get_session
 from app.util.log import logger
+
 PLACEHOLDER_COVER_URL = "https://picsum.photos/id/24/500/500"
 
 

--- a/templates/pages/Settings/Notifications/Index.jinja
+++ b/templates/pages/Settings/Notifications/Index.jinja
@@ -89,8 +89,8 @@
         <p class="flex flex-col text-xs opacity-60">
             Possible event variables:
             <span class="font-mono">
-                eventType, eventUser, eventUserExtraData, bookTitle, bookAuthors, bookCover, bookNarrators, bookASIN, torrentInfoHash,
-                sourceSizeMB, sourceTitle, indexerName, sourceProtocol
+                eventType, eventUser, eventUserExtraData, bookTitle, bookAuthors, bookCover, bookNarrators, bookASIN,
+                torrentInfoHash, sourceSizeMB, sourceTitle, indexerName, sourceProtocol
             </span>
             <span class="mt-1">Failed download event additionally has:</span>
             <span class="font-mono">errorStatus, errorReason</span>


### PR DESCRIPTION
I added the bookcover to be able to display it i.e. in discord. 
Example 1 - Automatic Request with Book Cover from Audible API
<img width="352" height="449" alt="grafik" src="https://github.com/user-attachments/assets/432712df-c5a4-4e71-86d5-01710a5b7959" />

Example 2 - Manual Request from User
<img width="351" height="446" alt="grafik" src="https://github.com/user-attachments/assets/1d5f6ff9-edfd-496f-9888-6f925a8d50d6" />


Example 3 - Test notification send at /settings/notifications
<img width="351" height="449" alt="grafik" src="https://github.com/user-attachments/assets/0d08221d-4176-4919-aff5-9429281d8656" />
