### PR TITLE
fix: ABS "mark existing books as downloaded" toggle has no effect (#222)

### DIFF
--- a/app/routers/api/search.py
+++ b/app/routers/api/search.py
@@ -10,6 +10,7 @@ from app.internal.audible.types import (
     audible_regions,
     get_region_from_settings,
 )
+from app.internal.audiobookshelf.client import abs_mark_downloaded_flags
 from app.internal.auth.authentication import AnyAuth, DetailedUser
 from app.internal.models import Audiobook, AudiobookWithRequests
 from app.util.connection import get_connection
@@ -47,6 +48,9 @@ async def search_books(
     merged: list[Audiobook] = []
     for res in results:
         merged.append(session.merge(res))
+
+    # Check ABS for existing books and mark as downloaded if found
+    await abs_mark_downloaded_flags(session, client_session, merged)
 
     return [
         AudiobookWithRequests(


### PR DESCRIPTION
## Fix: ABS "mark existing books as downloaded" check never invoked

Closes #222

### Problem

`abs_mark_downloaded_flags` was implemented in `app/internal/audiobookshelf/client.py` but never called from the search route, making the "Use ABS to mark existing books as downloaded" toggle completely non-functional.

### Fix

Call `abs_mark_downloaded_flags` in `search_books` after merging the Audible results, so existing books are checked against ABS and marked as downloaded before the response is returned.

### Changes

- `app/routers/api/search.py`: import and invoke `abs_mark_downloaded_flags` after building the merged result list